### PR TITLE
Add protection of stubbed methods from being called within a db transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.8 - WIP 
+
+### Added
+
+- Protection of stubbed methods from being called within a db transaction (nepalez)
+
+  ```yaml
+  ---
+  - class: GoogleTranslateDiff
+  - chain: translate
+  - within_transaction: false
+  - arguments:
+      - Color
+      - :from: en
+        :to:   de
+  - actions:
+      - return: Farbe
+  ```
+  
+  This method will raise an exception if the method is executed in a transaction:
+  
+  ```ruby
+  GoogleTranslateDiff.translate "Color", from: "en", to: "de"
+  # => "Farbe"  
+
+  # but not within a transaction
+  ActiveRecord::Base.transaction do
+    GoogleTranslateDiff.translate "Color", from: "en", to: "de"
+    # => raise #<Isolator::UnsafeOperationError ...>
+  end
+  ```
+  
+  We use the [isolator][isolator] gem under the hood
+
 ## [0.0.7] - [2019-07-01]
 
 ### Added
@@ -166,7 +200,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.1] - [2018-03-01]
 
-This is a first public release with features extracted from production app.
+This is the first public release with features extracted from production app.
 
 [0.0.1]: https://github.com/nepalez/fixturama/releases/tag/v0.0.1
 [0.0.2]: https://github.com/nepalez/fixturama/compare/v0.0.1...v0.0.2
@@ -175,3 +209,5 @@ This is a first public release with features extracted from production app.
 [0.0.5]: https://github.com/nepalez/fixturama/compare/v0.0.4...v0.0.5
 [0.0.6]: https://github.com/nepalez/fixturama/compare/v0.0.5...v0.0.6
 [0.0.7]: https://github.com/nepalez/fixturama/compare/v0.0.6...v0.0.7
+
+[isolator]: https://github.com/palkan/isolator

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in sms_aero.gemspec
 gemspec
 
 group :development, :test do

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ For message chains:
 - `class` for stubbed class
 - `chain` for messages chain
 - `arguments` (optional) for specific arguments
+- `within_transaction` (default to `true`) if the method can be called within a database transaction
 - `actions` for an array of actions for consecutive invocations of the chain
 
 For constants:
@@ -161,6 +162,7 @@ Every action either `return` some value, or `raise` some exception
 - class: Notifier
   chain:
     - create
+  within_transaction: false
   arguments:
     - :profileDeleted
     - <%= profile_id %>

--- a/fixturama.gemspec
+++ b/fixturama.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "factory_bot", "~> 4.0"
   gem.add_runtime_dependency "rspec", "~> 3.0"
   gem.add_runtime_dependency "hashie", "~> 3.6"
+  gem.add_runtime_dependency "isolator", "~> 0.6.1"
 
   gem.add_development_dependency "rake", "~> 10"
   gem.add_development_dependency "rspec-its", "~> 1.2"

--- a/lib/fixturama/stubs/chain.rb
+++ b/lib/fixturama/stubs/chain.rb
@@ -24,11 +24,11 @@ module Fixturama
     # @option (see Fixturama::Stubs::Arguments#add_action)
     # @return [self]
     #
-    def update!(actions:, arguments: nil, **)
+    def update!(actions:, arguments: nil, within_transaction: true, **)
       Utils.array(arguments).tap do |args|
         stub = find_by(args)
         unless stub
-          stub = Stubs::Chain::Arguments.new(self, args)
+          stub = Stubs::Chain::Arguments.new(self, within_transaction, args)
           stubs << stub
         end
         stub.add!(*actions)

--- a/spec/fixturama/stub_fixture/_spec.rb
+++ b/spec/fixturama/stub_fixture/_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe "stub_fixture" do
       end
     end
 
+    context "when called within a transaction" do
+      before do
+        allow(Isolator).to receive(:within_transaction?).and_return(true)
+      end
+
+      context "without the :within_transaction option" do
+        let(:arguments) { [2] }
+
+        it "raises an exception" do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context "when the option :within_transaction was set to false" do
+        let(:arguments) { [1] }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(Isolator::UnsafeOperationError)
+        end
+      end
+    end
+
     context "with several actions" do
       let(:arguments) { [2] * 4 }
 

--- a/spec/fixturama/stub_fixture/stub.yml
+++ b/spec/fixturama/stub_fixture/stub.yml
@@ -19,6 +19,7 @@
   chain:
     - new
     - pay
+  within_transaction: false
   arguments:
     - 1
   actions:


### PR DESCRIPTION
Use the `within_transaction: false` for the protection:

  ```yaml
  ---
  - class: GoogleTranslateDiff
  - chain: translate
  - within_transaction: false
  - arguments:
      - Color
      - :from: en
        :to:   de
  - actions:
      - return: Farbe
  ```

  This method will raise an exception if the method is executed in a transaction:

  ```ruby
  GoogleTranslateDiff.translate "Color", from: "en", to: "de"
  # => "Farbe"  

  # but not within a transaction
  ActiveRecord::Base.transaction do
    GoogleTranslateDiff.translate "Color", from: "en", to: "de"
    # => raise #<Isolator::UnsafeOperationError ...>
  end
  ```