### PR TITLE
Eased the FactoryBot gem version constraint

### DIFF
--- a/fixturama.gemspec
+++ b/fixturama.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.2"
 
-  gem.add_runtime_dependency "factory_bot", "~> 4.0"
+  gem.add_runtime_dependency "factory_bot", ">= 4.0"
   gem.add_runtime_dependency "rspec", "~> 3.0"
   gem.add_runtime_dependency "hashie", "~> 3.0"
   gem.add_runtime_dependency "webmock", "~> 3.0"


### PR DESCRIPTION
Current gem specifications lock FactoryBot gem version to an old one.

That being said, the interface used by Fixturama is limited to `FactoryBot.create_list()`.

This API is still up to date with current FactoryBot version so we can broaden the gem version constraint to anything above 4.1.0.

That's what this pull request does, but I do think that the dependency should be removed and let in the hands of the user.